### PR TITLE
Add Maven tutorial page

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,16 @@
                 </div>
             </a>
 
+            <a href="maven-tutorial.html" class="page-item">
+                <div class="page-title">
+                    <span class="page-icon">☕</span>
+                    Maven 教程
+                </div>
+                <div class="page-description">
+                    Java 构建工具 Maven 的使用指南和教程
+                </div>
+            </a>
+
             <a href="uv-tutorial.html" class="page-item">
                 <div class="page-title">
                     <span class="page-icon">⚡</span>

--- a/maven-tutorial.html
+++ b/maven-tutorial.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Maven 完整教程</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background-color: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #c71a36;
+            text-align: center;
+            border-bottom: 3px solid #c71a36;
+            padding-bottom: 10px;
+        }
+        h2 {
+            color: #2c3e50;
+            margin-top: 30px;
+            padding: 10px;
+            background-color: #ecf0f1;
+            border-left: 5px solid #c71a36;
+        }
+        code {
+            background-color: #f8f9fa;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-family: 'Courier New', monospace;
+            color: #c71a36;
+        }
+        pre {
+            background-color: #2c3e50;
+            color: #ecf0f1;
+            padding: 15px;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin: 15px 0;
+        }
+        pre code {
+            background: none;
+            color: inherit;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>☕ Maven 完整教程</h1>
+        <p>Maven 是一个基于项目对象模型 (POM) 的 Java 项目构建和依赖管理工具。本教程涵盖安装、项目创建以及常用命令。</p>
+
+        <h2>1. 安装 Maven</h2>
+        <p>从 <a href="https://maven.apache.org/" target="_blank" rel="noopener">Apache Maven 官网</a> 下载二进制包，解压后将 <code>bin</code> 目录添加到环境变量 <code>PATH</code>。通过以下命令验证安装：</p>
+        <pre><code>mvn -v</code></pre>
+
+        <h2>2. 创建项目</h2>
+        <p>使用 Archetype 快速生成一个 Java 项目：</p>
+        <pre><code>mvn archetype:generate -DgroupId=com.example -DartifactId=demo -DarchetypeArtifactId=maven-archetype-quickstart -DinteractiveMode=false</code></pre>
+
+        <h2>3. 常用命令</h2>
+        <ul>
+            <li><code>mvn compile</code> 编译源码</li>
+            <li><code>mvn test</code> 运行测试</li>
+            <li><code>mvn package</code> 打包项目</li>
+            <li><code>mvn clean</code> 清理构建输出</li>
+        </ul>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Maven tutorial covering installation, project creation and common commands
- link new Maven page from navigation index

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68be32a436288320b413accfa3ff11d3